### PR TITLE
Handle debug permission with user gesture

### DIFF
--- a/background.js
+++ b/background.js
@@ -439,19 +439,14 @@ async function handleDebugToggle(enabled) {
   await chrome.storage.local.set({debugToPage});
 
   if (debugToPage && !wasEnabled) {
-    // Request permission when enabling debugging
-    const granted = await chrome.permissions.request({
+    const hasPermission = await chrome.permissions.contains({
       permissions: ["scripting"],
     });
-    if (granted) {
-      return {success: true, debugEnabled: true};
-    } else {
+    if (!hasPermission) {
       debugToPage = false;
       await chrome.storage.local.set({debugToPage: false});
-      return {success: false, debugEnabled: false, error: "Permission denied"};
+      return {success: false, debugEnabled: false, error: "Permission missing"};
     }
-  } else if (!debugToPage && wasEnabled) {
-    // No additional cleanup needed when disabling debug
   }
 
   return {success: true, debugEnabled: debugToPage};

--- a/js/ui/PopupUI.js
+++ b/js/ui/PopupUI.js
@@ -164,18 +164,31 @@ export class PopupUI {
 
     this.elements.debugToPageToggle.addEventListener("change", () => {
       const enabled = this.elements.debugToPageToggle.checked;
-      chrome.runtime.sendMessage(
-        {action: "toggleDebugToPage", enabled},
-        (response) => {
-          if (
-            response?.debugEnabled !== undefined &&
-            response.debugEnabled !== enabled
-          ) {
-            this.elements.debugToPageToggle.checked = response.debugEnabled;
+
+      if (enabled) {
+        chrome.permissions.request({permissions: ["scripting"]}, (granted) => {
+          if (granted) {
+            chrome.runtime.sendMessage(
+              {action: "toggleDebugToPage", enabled: true},
+              (response) => {
+                if (
+                  response?.debugEnabled !== undefined &&
+                  response.debugEnabled !== true
+                ) {
+                  this.elements.debugToPageToggle.checked = response.debugEnabled;
+                }
+              }
+            );
+            chrome.storage.local.set({debugToPage: true});
+          } else {
+            this.elements.debugToPageToggle.checked = false;
+            chrome.storage.local.set({debugToPage: false});
           }
-        }
-      );
-      chrome.storage.local.set({debugToPage: enabled});
+        });
+      } else {
+        chrome.runtime.sendMessage({action: "toggleDebugToPage", enabled: false});
+        chrome.storage.local.set({debugToPage: false});
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- Request `scripting` permission from the popup's toggle to ensure it runs during a user gesture
- Verify the permission before enabling debug logging in background script

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check background.js`
- `node --check js/ui/PopupUI.js`


------
https://chatgpt.com/codex/tasks/task_e_689c6cfc8ff483238f2b7c46f02ddacb